### PR TITLE
Updates apache2-utils to version 2.4.38-r3

### DIFF
--- a/magicmirror/Dockerfile
+++ b/magicmirror/Dockerfile
@@ -16,7 +16,7 @@ RUN \
   apk add --no-cache \
     nodejs=8.14.0-r0 \
     npm=8.14.0-r0 \
-    apache2-utils=2.4.35-r0 \
+    apache2-utils=2.4.38-r3 \
     nginx=1.14.2-r0 \
     lua-resty-http=0.12-r1 \
     nginx-mod-http-lua=1.14.2-r0 \


### PR DESCRIPTION

# Proposed Changes

This PR will update `apache2-utils` to version `2.4.38-r3`.

This PR was created automatically, please check the "Files changed" tab
before merging!

***

This PR was created with [repoupdater][repoupdater] :tada:

[repoupdater]: https://pypi.org/project/repoupdater/
